### PR TITLE
Move front-end location back to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "ahope",
   "version": "2.0.0",
   "private": true,
-  "homepage": "front-end",
   "dependencies": {
     "@google-cloud/storage": "^1.6.0",
     "ajv": "^6.5.5",

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -11,6 +11,16 @@
 export default function register() {
     if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
       window.addEventListener('load', () => {
+        navigator.serviceWorker
+          .register('/dummy.js', {scope : '/parse'})
+          .catch(error => {
+            console.error('Error during dummy service worker registration for /parse scope:', error);
+          });
+        navigator.serviceWorker
+          .register('/dummy.js', {scope : '/dashboard'})
+          .catch(error => {
+            console.error('Error during dummy service worker registration for /dashboard scope:', error);
+          });
         const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
         navigator.serviceWorker
           .register(swUrl)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
     },
     output: {
         path: path.join(__dirname, 'build'),
-        publicPath: '/front-end',
+        publicPath: '',
         filename: '[name].js'
     },
     resolve: {


### PR DESCRIPTION
As a part of the effort, register dummy service worker for /dashboard and /parse to allow bypass of root scope service worker.

This PR should be merged in conjunction with merge of [changes to the backend service](https://github.com/evandana/keep-ahope-gcp/pull/6).